### PR TITLE
Fix initialization to not crash if the controller is not present

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-2.1-only
+//
+// src/error.h
+// XPlane Plugin for HoneyComb Bravo Throttle Controller
+//
+// Copyright (C) 2005 Isaac Gelado
+
+
+
+#ifndef ERROR_H_
+#define ERROR_H_
+
+#include <expected>
+#include <iostream>
+
+enum class error {
+    not_detected,
+    hid_error,
+    api_command,
+    api_menu,
+    api_loop,
+
+};
+
+template<typename T>
+using result_type = std::expected<T, error>;
+
+static inline
+std::ostream &
+operator<<(std::ostream & os, const error & e) noexcept {
+    switch(e) {
+        case error::not_detected:
+            os << "Controller not Detected";
+            break;
+        case error::hid_error:
+            os << "HID Subsystem not Available";
+            break;
+        case error::api_command:
+            os << "Failed to add Command to XPlane";
+            break;
+        case error::api_menu:
+            os << "Failed to add Menu to XPlane";
+            break;
+        case error::api_loop:
+            os << "Failed to add Callback to XPlane";
+            break;
+    }
+    return os;
+}
+
+#endif

--- a/src/knob.cpp
+++ b/src/knob.cpp
@@ -182,7 +182,7 @@ commands::ap_knob_down(XPLMCommandRef cmd, XPLMCommandPhase phase, void * ref) n
 
 
 
-std::expected<commands::ptr_type, int>
+result_type<commands::ptr_type>
 commands::init(const state & state) noexcept
 {
     ptr_type ret(new commands(state));
@@ -190,19 +190,19 @@ commands::init(const state & state) noexcept
         ret.get()->*desc.cmd = XPLMCreateCommand(desc.path, desc.desc);
         if(ret.get()->*desc.cmd == nullptr) {
             logger() << "Failed to register Selection Command";
-            return std::unexpected(0);
+            return std::unexpected(error::api_command);
         }
         XPLMRegisterCommandHandler(ret.get()->*desc.cmd, ap_knob_select, 1, reinterpret_cast<void *>(ret.get()));
     }
     ret->inc_ = XPLMCreateCommand("HCBravo/Inc", "Autopilot Knob Up");
     if(ret->inc_ == nullptr) {
         logger() << "Failed to register Inc Command";
-        return std::unexpected(0);
+        return std::unexpected(error::api_command);
     }
     ret->dec_ = XPLMCreateCommand("HCBravo/Dec", "Autopilot Knob Down");
     if(ret->dec_ == nullptr) {
         logger() << "Failed to register Dec Command";
-        return std::unexpected(0);
+        return std::unexpected(error::api_command);
     }
 
     XPLMRegisterCommandHandler(ret->inc_, ap_knob_up, 1, reinterpret_cast<void *>(ret.get()));

--- a/src/knob.h
+++ b/src/knob.h
@@ -15,6 +15,8 @@
 #include <expected>
 #include <memory>
 
+#include "error.h"
+
 enum class selector : size_t {
     alt = 0,
     vs = 1,
@@ -79,7 +81,7 @@ public:
     ~commands() noexcept;
 
     static
-    std::expected<ptr_type, int>
+    result_type<ptr_type>
     init(const state & state) noexcept;
 
     inline

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,7 @@ XPluginStart(char * name, char * sig, char * desc) {
     XPLMEnableFeature("XPLM_USE_NATIVE_PATHS", 1);
     auto state = state::init();
     if(state.has_value() == false) {
-       logger() << "Failed to initialize Plugin";
+       logger() << "Failed to initialize Plugin: " << state.error();
        return 0;
     }
     plugin_state.emplace(std::move(state.value()));
@@ -48,6 +48,7 @@ XPluginStart(char * name, char * sig, char * desc) {
 PLUGIN_API
 void
 XPluginStop(void) {
+    logger() << "Unloading Plugin";
     plugin_state = std::nullopt;
 }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -111,7 +111,7 @@ state::flight_iteration(float call, float iter, int counter, void * _this) noexc
     return -1.0;
 }
 
-std::expected<state::ptr_type, int>
+result_type<state::ptr_type>
 state::init() noexcept
 {
     state::ptr_type st = state::ptr_type(new state());
@@ -120,18 +120,19 @@ state::init() noexcept
     int res = hid_init();
     if(res < 0) {
         logger() << "Failed to initialize HID";
-        return std::unexpected(0);
+        return std::unexpected(error::hid_error);
     }
     st->hid_ = hid_open(0x294b, 0x1901, nullptr);
     if(st->hid_ == nullptr) {
-        logger() << "Failed to Open HoneyComb Bravo Quadrant";
-        return std::unexpected(0);
+        logger() << "Open HoneyComb Bravo Quadrant not Detected";
+        return std::unexpected(error::not_detected);
     }
     logger() << "HoneyComb Bravo Throttle Detected";
     st->leds_.hid_ = st->hid_;
 
     auto commands = commands::init(*st);
     if(commands.has_value() == false) {
+        hid_close(st->hid_);
         logger() << "Failed to Register HoneyComb Bravo Commands";
         return std::unexpected(commands.error());
     }
@@ -144,12 +145,14 @@ state::init() noexcept
     int item = XPLMAppendMenuItem(XPLMFindPluginsMenu(), "HoneyComb Bravo", nullptr, 1);
     st->menu_ = XPLMCreateMenu("HoneyComb Bravo", XPLMFindPluginsMenu(), item, &state::menu_handler, st.get());
     if(XPLMAppendMenuItem(st->menu_, "Reload Aircraft Profiles", reinterpret_cast<void *>(0), 0) < 0) {
+        XPLMDestroyMenu(st->menu_);
         logger() << "Failed to Create HoneyComb Bravo Menu (Reload Aircraft Profiles)";
-        return std::unexpected(0);
+        return std::unexpected(error::api_menu);
     }
     if(XPLMAppendMenuItem(st->menu_, "Reload All Plugins", reinterpret_cast<void *>(1), 0) < 0) {
+        XPLMDestroyMenu(st->menu_);
         logger() << "Failed to Create HoneyComb Bravo Menu (Reload All Plugins)";
-        return std::unexpected(0);
+        return std::unexpected(error::api_menu);
     }
 
     logger() << "Creating Flight Loop Logic";
@@ -161,8 +164,9 @@ state::init() noexcept
     };
     st->flight_loop_ = XPLMCreateFlightLoop(&fl_params);
     if(st->flight_loop_ == nullptr) {
+        XPLMDestroyMenu(st->menu_);
         logger() << "Failed to Create Flight Loop";
-        return std::unexpected(0);
+        return std::unexpected(error::api_loop);
     }
 
     return st;

--- a/src/state.h
+++ b/src/state.h
@@ -12,12 +12,12 @@
 #include <XPLM/XPLMMenus.h>
 #include <XPLM/XPLMProcessing.h>
 
-#include <expected>
 #include <optional>
 #include <string>
 
 #include <hidapi.h>
 
+#include "error.h"
 #include "knob.h"
 #include "led.h"
 #include "profile.h"
@@ -64,7 +64,7 @@ public:
     }
 
     static
-    std::expected<state::ptr_type, int>
+    result_type<state::ptr_type>
     init() noexcept;
 
     void


### PR DESCRIPTION
Fix initialization to prevent the plugin from loading if the HCBravo controller is not found
Start using custom error codes