### PR TITLE
[codex] Harden plugin safety paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+permissions:
+  actions: read
+  contents: write
+
 jobs:
   build:
     strategy:
@@ -35,6 +39,18 @@ jobs:
         run: |
           echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
+      - name: Validate Release Version
+        id: version
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Invalid release version: $RELEASE_VERSION" >&2
+            exit 1
+          fi
+          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Gather Linux Package
         uses: actions/download-artifact@v5
         with:
@@ -61,27 +77,31 @@ jobs:
  
       - name: Pack Plugins 
         working-directory: ${{ steps.strings.outputs.build-output-dir }}
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           install -D ubuntu/hcbravo.xpl Resources/plugins/hcbravo/lin_x64/hcbravo.xpl
           install -D macos/hcbravo.xpl Resources/plugins/hcbravo/mac_x64/hcbravo.xpl
           install -D windows/Release/hcbravo.xpl Resources/plugins/hcbravo/win_x64/hcbravo.xpl
           cp -R "${{ github.workspace }}/ext/AeroSoft/joystick configs" "Resources/joystick configs/"
-          cp -R ${{ github.workspace }}/conf Resources/plugins/hcbravo/conf
+          cp -R "${{ github.workspace }}/conf" Resources/plugins/hcbravo/conf
           mkdir -p Output/preferences
           cp "${{ github.workspace }}"/profiles/*.prf Output/preferences/
-          zip -r hcbravo-v${{ github.event.inputs.version }}.zip Resources Output
+          zip -r "hcbravo-v${RELEASE_VERSION}.zip" Resources Output
 
       - name: Create Release Tag
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          git tag v${{ github.event.inputs.version }}
-          git push origin v${{ github.event.inputs.version }}
+          git tag "v${RELEASE_VERSION}"
+          git push origin "v${RELEASE_VERSION}"
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ github.event.inputs.version }}
-          name: 'HCBravo Release v${{ github.event.inputs.version }}'
-          files: ${{ steps.strings.outputs.build-output-dir }}/hcbravo-v${{ github.event.inputs.version }}.zip
+          tag_name: v${{ steps.version.outputs.version }}
+          name: 'HCBravo Release v${{ steps.version.outputs.version }}'
+          files: ${{ steps.strings.outputs.build-output-dir }}/hcbravo-v${{ steps.version.outputs.version }}.zip
       

--- a/src/error.h
+++ b/src/error.h
@@ -19,6 +19,7 @@ enum class error {
     api_command,
     api_menu,
     api_loop,
+    configuration,
 
 };
 
@@ -43,6 +44,9 @@ operator<<(std::ostream & os, const error & e) noexcept {
             break;
         case error::api_loop:
             os << "Failed to add Callback to XPlane";
+            break;
+        case error::configuration:
+            os << "Failed to load Plugin Configuration";
             break;
     }
     return os;

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -9,12 +9,15 @@
 
 #include <cstring>
 
-led_state::led_state() noexcept 
+led_state::led_state() noexcept :
+    hid_(nullptr)
 {
     ::memset(reinterpret_cast<void *>(&u), 0, sizeof(u));
 }
 
-led_state::led_state(led_state && other) noexcept 
+led_state::led_state(led_state && other) noexcept :
+    hid_(other.hid_)
 {
     ::memcpy(&u, &other.u, sizeof(u));
+    other.hid_ = nullptr;
 }

--- a/src/led.h
+++ b/src/led.h
@@ -87,11 +87,16 @@ public:
             if(u.state_.banks_[n] != mask.banks_[n]) break;
         }
         if(n == LED_NR_BANKS) return;
-        ::memcpy(u.state_.banks_, mask.banks_, sizeof(mask.banks_));
-        int ret = hid_send_feature_report(this->hid_, this->u.buffer_, sizeof(hid_data));
+        hid_data next_state;
+        ::memcpy(&next_state, &u.state_, sizeof(next_state));
+        ::memcpy(next_state.banks_, mask.banks_, sizeof(mask.banks_));
+        int ret = hid_send_feature_report(this->hid_,
+            reinterpret_cast<const unsigned char *>(&next_state), sizeof(next_state));
         if(ret < 0) {
             logger() << "Failed to update LED state";
+            return;
         }
+        ::memcpy(&u.state_, &next_state, sizeof(u.state_));
     }
 
 };

--- a/src/profile-data-ref-impl.h
+++ b/src/profile-data-ref-impl.h
@@ -22,7 +22,7 @@ class data_ref;
 
 template<typename T>
 std::expected<T, int>
-base_data_ref::build(const YAML::Node & node) noexcept
+base_data_ref::build(const YAML::Node & node)
 {
     XPLMDataRef data_ref = nullptr;
     bool invert = false;
@@ -84,7 +84,7 @@ public:
 
     static inline
     std::expected<data_ref, int>
-    build(const YAML::Node & node) noexcept {
+    build(const YAML::Node & node) {
         return base_data_ref::build<data_ref>(node);
     }
 
@@ -118,7 +118,7 @@ public:
 
     static inline
     std::expected<data_ref, int>
-    build(const YAML::Node & node) noexcept {
+    build(const YAML::Node & node) {
         auto ret = base_data_ref::build<data_ref>(node);
         if(ret.has_value()) {
             if(node.IsMap()) {
@@ -171,7 +171,7 @@ public:
 
     static inline
     std::expected<data_ref, int>
-    build(const YAML::Node & node) noexcept {
+    build(const YAML::Node & node) {
         auto ret = base_data_ref::build<data_ref>(node);
         if(ret.has_value()) {
             if(node.IsMap()) {

--- a/src/profile-data-ref-impl.h
+++ b/src/profile-data-ref-impl.h
@@ -26,12 +26,19 @@ base_data_ref::build(const YAML::Node & node)
 {
     XPLMDataRef data_ref = nullptr;
     bool invert = false;
-    std::optional<size_t> index = std::nullopt;
+    std::optional<int> index = std::nullopt;
 
     if(node.IsMap()) {
         data_ref = XPLMFindDataRef(node["key"].as<std::string>().c_str());
         if(node["invert"]) invert = node["invert"].as<bool>();
-        if(node["index"]) index = node["index"].as<size_t>();
+        if(node["index"]) {
+            int parsed_index = node["index"].as<int>();
+            if(parsed_index < 0) {
+                logger() << "Invalid negative index in DataRef node '" << node << "'";
+                return std::unexpected(0);
+            }
+            index = parsed_index;
+        }
     }
     else if(node.IsScalar()) {
         data_ref = XPLMFindDataRef(node.as<std::string>().c_str());
@@ -49,20 +56,16 @@ base_data_ref::build(const YAML::Node & node)
     XPLMDataRefInfo_t info;
     info.structSize = sizeof(info);
     XPLMGetDataRefInfo(data_ref, &info);
-    switch(info.type) {
-        case xplmType_IntArray:
-        case xplmType_FloatArray:
-            if(!index) {
-                logger() << "Detected Array DataRef '" << info.name << "', but no index was provided. Assuming index 0";
-                index = static_cast<size_t>(0);
-            }
-            break;
-        default:
-            if(index) {
-                logger() << "Detected Scalar DataRef '" << info.name << "', but an index was provided. Ignoring provided index";
-                index = std::nullopt;
-            }
-            break;
+    const bool is_array = (info.type & (xplmType_IntArray | xplmType_FloatArray)) != 0;
+    if(is_array) {
+        if(!index) {
+            logger() << "Detected Array DataRef '" << info.name << "', but no index was provided. Assuming index 0";
+            index = 0;
+        }
+    }
+    else if(index) {
+        logger() << "Detected Scalar DataRef '" << info.name << "', but an index was provided. Ignoring provided index";
+        index = std::nullopt;
     }
 
     return T(std::move(data_ref), invert, index);
@@ -74,7 +77,7 @@ class data_ref<bool> : public bool_data_ref {
 protected:
     inline
     data_ref(XPLMDataRef && data_ref, bool invert,
-            std::optional<size_t> index) noexcept :
+            std::optional<int> index) noexcept :
         bool_data_ref(std::move(data_ref), invert, index)
     {}
 
@@ -108,7 +111,7 @@ protected:
 
     inline
     data_ref(XPLMDataRef && data_ref, bool invert,
-            std::optional<size_t> index) noexcept :
+            std::optional<int> index) noexcept :
         bool_data_ref(std::move(data_ref), invert, index)
     {}
 
@@ -160,7 +163,7 @@ protected:
 
     inline
     data_ref(XPLMDataRef && data_ref, bool invert,
-            std::optional<size_t> index) noexcept :
+            std::optional<int> index) noexcept :
         bool_data_ref(std::move(data_ref), invert, index)
     {}
 
@@ -192,7 +195,7 @@ public:
     bool is_set() const noexcept final {
         float value = this->get();
         if(this->values_.empty()) {
-            return this->invert_ ? this->get() == 0.0f : this->get() != 0.0f;
+            return this->invert_ ? value == 0.0f : value != 0.0f;
         }
         // When values are specified, we compare against the targets
         for(const auto & v : this->values_) {
@@ -205,9 +208,11 @@ public:
     float get() const noexcept {
         if(this->data_ref_ == nullptr) return 0.0f;
         if(this->index_) {
-            float ret;
-            XPLMGetDatavf(this->data_ref_, &ret,
-                this->index_.value(), 1);
+            float ret = 0.0f;
+            if(XPLMGetDatavf(this->data_ref_, &ret, this->index_.value(), 1) != 1) {
+                logger() << "Failed to read indexed float DataRef @ " << this->index_.value();
+                return 0.0f;
+            }
             return ret;
         }
         return XPLMGetDataf(this->data_ref_);

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -10,13 +10,14 @@
 
 #include <XPLM/XPLMUtilities.h>
 
+#include <exception>
 #include <memory>
 #include <optional>
 
 
 static
 std::optional<bool_data_ref::ptr_type>
-make_bool_data_ref(const YAML::Node & node) noexcept
+make_bool_data_ref(const YAML::Node & node)
 {
     if(!node) return std::nullopt;
     if(node.IsMap() == false) {
@@ -45,7 +46,7 @@ make_bool_data_ref(const YAML::Node & node) noexcept
     return std::nullopt;
 }
 
-value_data_ref::value_data_ref(const YAML::Node & node) noexcept {
+value_data_ref::value_data_ref(const YAML::Node & node) {
     if(!node) return;
 
     if(node.IsSequence()) {
@@ -68,7 +69,7 @@ airspeed_data_ref::airspeed_data_ref(
 {}
 
 std::expected<airspeed_data_ref, int>
-airspeed_data_ref::build(const YAML::Node & node) noexcept {
+airspeed_data_ref::build(const YAML::Node & node) {
     if(!node.IsMap()) {
         logger() << "IAS node has invalid format";
         return std::unexpected(0);
@@ -100,7 +101,7 @@ airspeed_data_ref::build(const YAML::Node & node) noexcept {
 template<typename T>
 static inline
 std::optional<data_ref<T>>
-build_optional_data_ref(const YAML::Node & node, const std::string & key) noexcept
+build_optional_data_ref(const YAML::Node & node, const std::string & key)
 {
     logger() << "Checking for '" << key << "'";
     if(!node.IsMap() or !node[key]) {
@@ -119,14 +120,14 @@ template<typename T>
 static inline
 std::optional<data_ref<T>>
 build_optional_data_ref(const YAML::Node & node, const std::string & key,
-        const std::string & alias) noexcept
+        const std::string & alias)
 {
     auto ret = build_optional_data_ref<T>(node, key);
     if(ret.has_value()) return ret;
     return build_optional_data_ref<T>(node, alias);
 }
 
-autopilot_dial_data_ref::autopilot_dial_data_ref(std::optional<airspeed_data_ref> && ias, const YAML::Node & node) noexcept :
+autopilot_dial_data_ref::autopilot_dial_data_ref(std::optional<airspeed_data_ref> && ias, const YAML::Node & node) :
     ias_(std::move(ias)),
     course_(build_optional_data_ref<float>(node, "crs", "course")),
     heading_(build_optional_data_ref<float>(node, "hdg", "heading")),
@@ -135,7 +136,7 @@ autopilot_dial_data_ref::autopilot_dial_data_ref(std::optional<airspeed_data_ref
 {}
 
 std::expected<autopilot_dial_data_ref, int>
-autopilot_dial_data_ref::build(const YAML::Node & node) noexcept
+autopilot_dial_data_ref::build(const YAML::Node & node)
 {
     logger() << "Reading Autopilot Dials";
     if(node.IsMap() == false) {
@@ -155,7 +156,7 @@ autopilot_dial_data_ref::build(const YAML::Node & node) noexcept
     return autopilot_dial_data_ref(std::nullopt, node);
 }
 
-autopilot_mode_data_ref::autopilot_mode_data_ref(const YAML::Node & node) noexcept :
+autopilot_mode_data_ref::autopilot_mode_data_ref(const YAML::Node & node) :
     hdg_(node["hdg"] ? std::optional(value_data_ref(node["hdg"])) : std::nullopt),
     nav_(node["nav"] ? std::optional(value_data_ref(node["nav"])) : std::nullopt),
     apr_(node["apr"] ? std::optional(value_data_ref(node["apr"])) : std::nullopt),
@@ -167,13 +168,18 @@ autopilot_mode_data_ref::autopilot_mode_data_ref(const YAML::Node & node) noexce
 {}
 
 std::expected<autopilot_mode_data_ref, int>
-autopilot_mode_data_ref::build(const YAML::Node & node) noexcept
+autopilot_mode_data_ref::build(const YAML::Node & node)
 {
     logger() << "Reading Autopilot Modes";
     // Only the AP annunciator is required
     if(!node["ap"]) return std::unexpected(1);
     
-    return autopilot_mode_data_ref(node);
+    auto ret = autopilot_mode_data_ref(node);
+    if(ret.ap_.empty()) {
+        logger() << "Invalid Autopilot AP DataRef Configuration";
+        return std::unexpected(0);
+    }
+    return ret;
 }
 
 
@@ -186,7 +192,7 @@ autopilot_data_ref::autopilot_data_ref(
 {}
 
 std::expected<autopilot_data_ref, int>
-autopilot_data_ref::build(const YAML::Node & node) noexcept
+autopilot_data_ref::build(const YAML::Node & node)
 {
     if(!node["modes"]) {
         logger() << "No modes defined for Autopilot";
@@ -211,22 +217,27 @@ autopilot_data_ref::build(const YAML::Node & node) noexcept
     return autopilot_data_ref(std::move(mode.value()), std::nullopt);
 }
 
-system_data_ref::system_data_ref(const YAML::Node & node) noexcept :
+system_data_ref::system_data_ref(const YAML::Node & node) :
     volts_(node["volts"]),
     gear_(node["gear"] ? std::optional(value_data_ref(node["gear"])) : std::nullopt)
 {}
 
 std::expected<system_data_ref, int>
-system_data_ref::build(const YAML::Node & node) noexcept
+system_data_ref::build(const YAML::Node & node)
 {
     // Only the AP annunciator is required
     if(!node["volts"]) return std::unexpected(1);
-    return system_data_ref(node);
+    auto ret = system_data_ref(node);
+    if(ret.volts_.empty()) {
+        logger() << "Invalid System Volts DataRef Configuration";
+        return std::unexpected(0);
+    }
+    return ret;
 }
 
 
 
-annunciator_data_ref::annunciator_data_ref(const YAML::Node & node) noexcept :
+annunciator_data_ref::annunciator_data_ref(const YAML::Node & node) :
     master_warn_(node["master_warn"] ? std::optional(value_data_ref(node["master_warn"])) : std::nullopt),
     eng_fire_(node["eng_fire"] ? std::optional(value_data_ref(node["eng_fire"])) : std::nullopt),
     oil_low_(node["oil_low"] ? std::optional(value_data_ref(node["oil_low"])) : std::nullopt),
@@ -244,7 +255,7 @@ annunciator_data_ref::annunciator_data_ref(const YAML::Node & node) noexcept :
 {}
 
 std::expected<annunciator_data_ref, int>
-annunciator_data_ref::build(const YAML::Node & node) noexcept 
+annunciator_data_ref::build(const YAML::Node & node)
 {
     logger() << "Reading Annunciator";
     return annunciator_data_ref(node);
@@ -266,84 +277,87 @@ profile::profile(std::string && name,
 
 std::expected<profile::ptr_type, int>
 profile::from_yaml(const std::string & path) noexcept {
-    logger() << "Loading YAML File " << path;
-    YAML::Node node;
     try {
-        node = YAML::LoadFile(path);
-    }
-    catch(const YAML::Exception & ex) {
-        logger() << "Failed to load YAML file '" << path << "': " << ex.what();
-        return std::unexpected(0);
-    }
-    if(!node["name"]) {
-        logger() << "Profile does not include a name";
-        return std::unexpected(0);
-    }
-    
-    std::vector<std::string> aircrafts;
-    if(!node["aircrafts"] or node["aircrafts"].IsSequence() == false) {
-        logger() << "Profile does not include supported aircrafts";
-    }
-    else {
-        for(const auto & aircraft : node["aircrafts"]) {
-            if(aircraft.Type() != YAML::NodeType::Scalar) {
-                logger() << "Invalid Aircraft '" << node << "'";
+        logger() << "Loading YAML File " << path;
+        YAML::Node node = YAML::LoadFile(path);
+
+        if(!node["name"]) {
+            logger() << "Profile does not include a name";
+            return std::unexpected(0);
+        }
+        
+        std::vector<std::string> aircrafts;
+        if(!node["aircrafts"] or node["aircrafts"].IsSequence() == false) {
+            logger() << "Profile does not include supported aircrafts";
+        }
+        else {
+            for(const auto & aircraft : node["aircrafts"]) {
+                if(aircraft.Type() != YAML::NodeType::Scalar) {
+                    logger() << "Invalid Aircraft '" << node << "'";
+                    continue;
+                }
+                aircrafts.emplace_back(aircraft.as<std::string>());
+            }
+        }
+
+        if(!node["models"] or node["models"].IsSequence() == false) {
+            logger() << "Profile does not include supported models";
+            return std::unexpected(0);
+        }
+        std::vector<std::string> models;
+        for(const auto & model : node["models"]) {
+            if(model.Type() != YAML::NodeType::Scalar) {
+                logger() << "Invalid Model '" << node << "'";
                 continue;
             }
-            aircrafts.emplace_back(aircraft.as<std::string>());
+            models.emplace_back(model.as<std::string>());
         }
-    }
-
-    if(!node["models"] or node["models"].IsSequence() == false) {
-        logger() << "Profile does not include supported models";
-        return std::unexpected(0);
-    }
-    std::vector<std::string> models;
-    for(const auto & model : node["models"]) {
-        if(model.Type() != YAML::NodeType::Scalar) {
-            logger() << "Invalid Model '" << node << "'";
-            continue;
-        }
-        models.emplace_back(model.as<std::string>());
-    }
-    if(models.empty()) {
-        logger() << "No models defined for this profile";
-        return std::unexpected(0);
-    }
-
-    logger() << "Reading System Configuration";
-    if(!node["system"]) return std::unexpected(0);
-    auto system = system_data_ref::build(node["system"]);
-    if(system.has_value() == false) return std::unexpected(0);
-
-    logger() << "Reading Autopilot Configuration";
-    std::optional<autopilot_data_ref> autopilot;
-    if(node["autopilot"]) {
-        auto ap_ret = autopilot_data_ref::build(node["autopilot"]);
-        if(ap_ret.has_value() == false) {
-            logger() << "Invalid Autopilot Configuration";
+        if(models.empty()) {
+            logger() << "No models defined for this profile";
             return std::unexpected(0);
         }
-        autopilot = std::move(ap_ret.value());
-    }
 
-    logger() << "Reading Annunciator Configuration";
-    std::optional<annunciator_data_ref> annunciator;
-    if(node["annunciator"]) {
-        auto ann_ret = annunciator_data_ref::build(node["annunciator"]);
-        if(ann_ret.has_value() == false) {
-            logger() << "Invalid Annunciator Configuration";
-            return std::unexpected(0);
+        logger() << "Reading System Configuration";
+        if(!node["system"]) return std::unexpected(0);
+        auto system = system_data_ref::build(node["system"]);
+        if(system.has_value() == false) return std::unexpected(0);
+
+        logger() << "Reading Autopilot Configuration";
+        std::optional<autopilot_data_ref> autopilot;
+        if(node["autopilot"]) {
+            auto ap_ret = autopilot_data_ref::build(node["autopilot"]);
+            if(ap_ret.has_value() == false) {
+                logger() << "Invalid Autopilot Configuration";
+                return std::unexpected(0);
+            }
+            autopilot = std::move(ap_ret.value());
         }
-        annunciator = std::move(ann_ret.value());
-    }
 
-    return profile_ptr(new profile(
-        std::move(node["name"].as<std::string>()),
-        std::move(aircrafts),
-        std::move(models),
-        std::move(system.value()),
-        std::move(autopilot),
-        std::move(annunciator)
-    ));
+        logger() << "Reading Annunciator Configuration";
+        std::optional<annunciator_data_ref> annunciator;
+        if(node["annunciator"]) {
+            auto ann_ret = annunciator_data_ref::build(node["annunciator"]);
+            if(ann_ret.has_value() == false) {
+                logger() << "Invalid Annunciator Configuration";
+                return std::unexpected(0);
+            }
+            annunciator = std::move(ann_ret.value());
+        }
+
+        return profile_ptr(new profile(
+            node["name"].as<std::string>(),
+            std::move(aircrafts),
+            std::move(models),
+            std::move(system.value()),
+            std::move(autopilot),
+            std::move(annunciator)
+        ));
+    }
+    catch(const YAML::Exception & ex) {
+        logger() << "Failed to parse YAML file '" << path << "': " << ex.what();
+    }
+    catch(const std::exception & ex) {
+        logger() << "Failed to load YAML file '" << path << "': " << ex.what();
+    }
+    return std::unexpected(0);
 }

--- a/src/profile.h
+++ b/src/profile.h
@@ -23,11 +23,11 @@ class base_data_ref {
 protected:
     XPLMDataRef data_ref_;
     bool invert_;
-    std::optional<size_t> index_;
+    std::optional<int> index_;
 
     inline
     base_data_ref(XPLMDataRef && data_ref, bool invert,
-            std::optional<size_t> index) noexcept :
+            std::optional<int> index) noexcept :
         data_ref_(std::move(data_ref)),
         invert_(invert),
         index_(index)
@@ -58,7 +58,7 @@ public:
 
     inline
     bool_data_ref(XPLMDataRef && data_ref, bool invert,
-            std::optional<size_t> index) noexcept :
+            std::optional<int> index) noexcept :
         base_data_ref(std::move(data_ref), invert, index)
     {}
 

--- a/src/profile.h
+++ b/src/profile.h
@@ -38,7 +38,7 @@ public:
     template<typename T>
     static
     std::expected<T, int>
-    build(const YAML::Node & node) noexcept;
+    build(const YAML::Node & node);
 
     base_data_ref(base_data_ref && other) noexcept = default;
 
@@ -87,7 +87,7 @@ class value_data_ref {
 protected:
     std::vector<bool_data_ref::ptr_type> data_;
 public:
-    value_data_ref(const YAML::Node & node) noexcept;
+    value_data_ref(const YAML::Node & node);
 
     inline 
     bool
@@ -97,6 +97,10 @@ public:
         }
         return false;
     }
+
+    inline
+    bool
+    empty() const noexcept { return this->data_.empty(); }
 
 #if defined(HCBRAVO_PROFILE_TESTS)
     inline
@@ -126,7 +130,7 @@ public:
 
     static
     std::expected<airspeed_data_ref, int>
-    build(const YAML::Node &) noexcept;
+    build(const YAML::Node &);
 
     inline
     airspeed_unit
@@ -157,7 +161,7 @@ class autopilot_dial_data_ref {
     std::optional<float_data_ref> vs_;
     std::optional<float_data_ref> alt_;
 
-    autopilot_dial_data_ref(std::optional<airspeed_data_ref> && ias, const YAML::Node & node) noexcept;
+    autopilot_dial_data_ref(std::optional<airspeed_data_ref> && ias, const YAML::Node & node);
 public:
 
     autopilot_dial_data_ref(autopilot_dial_data_ref && other) noexcept = default;
@@ -167,7 +171,7 @@ public:
 
     static
     std::expected<autopilot_dial_data_ref, int>
-    build(const YAML::Node & node) noexcept;
+    build(const YAML::Node & node);
 
     inline
     const std::optional<airspeed_data_ref> &
@@ -216,13 +220,13 @@ class autopilot_mode_data_ref {
     std::optional<value_data_ref> ias_;
     value_data_ref ap_;
 
-    autopilot_mode_data_ref(const YAML::Node & node) noexcept;
+    autopilot_mode_data_ref(const YAML::Node & node);
 
 public:
 
     static
     std::expected<autopilot_mode_data_ref, int>
-    build(const YAML::Node & node) noexcept;
+    build(const YAML::Node & node);
 
     inline
     std::optional<bool>
@@ -323,7 +327,7 @@ public:
 
     static
     std::expected<autopilot_data_ref, int>
-    build(const YAML::Node & node) noexcept;
+    build(const YAML::Node & node);
 
     inline
     const autopilot_mode_data_ref &
@@ -338,13 +342,13 @@ class system_data_ref {
     value_data_ref volts_;
     std::optional<value_data_ref> gear_;
 
-    system_data_ref(const YAML::Node & node) noexcept;
+    system_data_ref(const YAML::Node & node);
 
 public:
 
     static
     std::expected<system_data_ref, int>
-    build(const YAML::Node & node) noexcept;
+    build(const YAML::Node & node);
 
     inline 
     bool 
@@ -383,12 +387,12 @@ class annunciator_data_ref {
     std::optional<value_data_ref> volt_low_;
     std::optional<value_data_ref> door_open_;
 
-    annunciator_data_ref(const YAML::Node & node) noexcept;
+    annunciator_data_ref(const YAML::Node & node);
 public:
 
     static
     std::expected<annunciator_data_ref, int>
-    build(const YAML::Node & node) noexcept;
+    build(const YAML::Node & node);
 
     inline 
     const std::optional<bool>

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -11,6 +11,7 @@
 #include <XPLM/XPLMUtilities.h>
 
 #include <algorithm>
+#include <exception>
 #include <expected>
 #include <filesystem>
 #include <memory>
@@ -36,9 +37,19 @@ state::menu_handler(void * _this, void * item) noexcept
     size_t id = reinterpret_cast<size_t>(item);
     switch(id) {
         case 0:
-            self->plane_ = std::nullopt;
             logger() << "Reloading Aircraft Profiles";
-            self->reload();
+            try {
+                self->reload();
+            }
+            catch(const std::exception & ex) {
+                logger() << "Failed to reload Aircraft Profiles: " << ex.what();
+                break;
+            }
+            catch(...) {
+                logger() << "Failed to reload Aircraft Profiles";
+                break;
+            }
+            self->plane_ = std::nullopt;
             logger() << "Setting Active Plane";
             self->load_plane();
             break;
@@ -118,7 +129,18 @@ state::flight_iteration(float call, float iter, int counter, void * _this) noexc
 result_type<state::ptr_type>
 state::init() noexcept
 {
-    state::ptr_type st = state::ptr_type(new state());
+    state::ptr_type st;
+    try {
+        st = state::ptr_type(new state());
+    }
+    catch(const std::exception & ex) {
+        logger() << "Failed to initialize Plugin State: " << ex.what();
+        return std::unexpected(error::configuration);
+    }
+    catch(...) {
+        logger() << "Failed to initialize Plugin State";
+        return std::unexpected(error::configuration);
+    }
 
     logger() << "Initializing HID";
     int res = hid_init();
@@ -217,7 +239,7 @@ read_data_ref_string(XPLMDataRef data_ref, char * buffer, size_t buffer_size, co
     return true;
 }
 
-state::state() noexcept :
+state::state() :
     hid_(nullptr),
     hid_initialized_(false),
     menu_(nullptr),
@@ -269,10 +291,10 @@ state::~state() noexcept
 }
 
 void
-state::reload() noexcept
+state::reload()
 {
-    if(profile_aircraft_map_.empty() == false) { profile_aircraft_map_.clear(); }
-    if(profile_model_map_.empty() == false) { profile_model_map_.clear(); }
+    profile_map_type aircraft_profiles;
+    profile_map_type model_profiles;
 
     logger() << "Reading Plugin Configuration Files";
     auto id = XPLMGetMyID();
@@ -308,7 +330,7 @@ state::reload() noexcept
             auto prof = profile::from_yaml(config_file.string());
             if(prof.has_value()) {
                 for(const auto &aircraft : prof.value()->aircrafts()) {
-                    auto ret = profile_aircraft_map_.emplace(aircraft, prof.value());
+                    auto ret = aircraft_profiles.emplace(aircraft, prof.value());
                     if(ret.second == false) {
                         logger() << "Not using '" << prof.value()->name() << "' for '" << aircraft 
                                  << "' because another profile already exists";
@@ -318,7 +340,7 @@ state::reload() noexcept
                     }
                 }
                 for(const auto &model : prof.value()->models()) {
-                    auto ret = profile_model_map_.emplace(model, prof.value());
+                    auto ret = model_profiles.emplace(model, prof.value());
                     if(ret.second == false) {
                         logger() << "Not using '" << prof.value()->name() << "' for ICAO '" << model 
                                  << "' because another profile already exists";
@@ -337,6 +359,8 @@ state::reload() noexcept
         }
         index += file_count;
     } while(index < total_conf_files);
+    profile_aircraft_map_.swap(aircraft_profiles);
+    profile_model_map_.swap(model_profiles);
     logger() << "Done loading plugin configuration";
 }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -10,6 +10,7 @@
 #include <XPLM/XPLMProcessing.h>
 #include <XPLM/XPLMUtilities.h>
 
+#include <algorithm>
 #include <expected>
 #include <filesystem>
 #include <memory>
@@ -193,6 +194,29 @@ static char * files_indexes[FILES_INDEX_SIZE];
 static const char * plane_icao_label_ = "sim/aircraft/view/acf_ICAO";
 static const char * plane_name_label_ = "sim/aircraft/view/acf_ui_name";
 
+static
+bool
+read_data_ref_string(XPLMDataRef data_ref, char * buffer, size_t buffer_size, const char * label) noexcept
+{
+    if(buffer_size == 0) return false;
+    buffer[0] = '\0';
+
+    if(data_ref == nullptr) {
+        logger() << "Cannot read missing DataRef '" << label << "'";
+        return false;
+    }
+
+    int ret = XPLMGetDatab(data_ref, buffer, 0, static_cast<int>(buffer_size - 1));
+    if(ret < 0) {
+        logger() << "Failed to read DataRef '" << label << "'";
+        return false;
+    }
+
+    size_t written = std::min(static_cast<size_t>(ret), buffer_size - 1);
+    buffer[written] = '\0';
+    return true;
+}
+
 state::state() noexcept :
     hid_(nullptr),
     hid_initialized_(false),
@@ -253,7 +277,13 @@ state::reload() noexcept
     logger() << "Reading Plugin Configuration Files";
     auto id = XPLMGetMyID();
     static char path[256];
+    path[0] = '\0';
     XPLMGetPluginInfo(id, nullptr, path, nullptr, nullptr);
+    path[sizeof(path) - 1] = '\0';
+    if(path[0] == '\0') {
+        logger() << "Cannot determine plugin path";
+        return;
+    }
     XPLMExtractFileAndPath(path);
     auto config_file_path = std::filesystem::absolute(std::string(path) + "/../conf");
     logger() << "Reading Configurations from " << config_file_path;
@@ -261,12 +291,16 @@ state::reload() noexcept
     int total_conf_files = 0;
     do {
         int file_count = 0;
-        XPLMGetDirectoryContents(
+        int directory_status = XPLMGetDirectoryContents(
             config_file_path.string().c_str(),  index, files_buffer, FILES_BUFFER_SIZE,
             files_indexes, FILES_INDEX_SIZE, &total_conf_files, &file_count
         );
+        if(directory_status == 0) {
+            logger() << "Configuration directory listing was truncated";
+        }
         logger() << "Read " << (index + file_count) << " file(s) from " << total_conf_files << " file(s)";
         for(auto n = 0; n < file_count; ++n) {
+            if(files_indexes[n] == nullptr) continue;
             auto config_file = config_file_path / std::string(files_indexes[n]);
             logger() << "Found " << config_file << " in configuration file ( " << config_file.extension() << ")";
             if(config_file.extension() != ".yaml") continue;
@@ -295,8 +329,14 @@ state::reload() noexcept
                 }
             }
         }
+        if(file_count <= 0) {
+            if(index < total_conf_files) {
+                logger() << "Stopping configuration reload because directory iteration did not advance";
+            }
+            break;
+        }
         index += file_count;
-    } while(index != total_conf_files);
+    } while(index < total_conf_files);
     logger() << "Done loading plugin configuration";
 }
 
@@ -305,10 +345,8 @@ state::load_plane() noexcept
 {
     static char icao_name[64];
     static char ui_name[256];
-    int ret = XPLMGetDatab(plane_icao_data_ref_, icao_name, 0, 64);
-    if(ret < 64) icao_name[ret] = '\0';
-    ret = XPLMGetDatab(plane_name_data_ref_, ui_name, 0, 256);
-    if(ret < 256) ui_name[ret] = '\0';
+    read_data_ref_string(plane_icao_data_ref_, icao_name, sizeof(icao_name), plane_icao_label_);
+    read_data_ref_string(plane_name_data_ref_, ui_name, sizeof(ui_name), plane_name_label_);
     logger() << "Aircraft '" << ui_name << "' (" << icao_name << ")";
 
     // First try to get a match for the specific Aircraft

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -125,6 +125,7 @@ state::init() noexcept
         logger() << "Failed to initialize HID";
         return std::unexpected(error::hid_error);
     }
+    st->hid_initialized_ = true;
     st->hid_ = hid_open(0x294b, 0x1901, nullptr);
     if(st->hid_ == nullptr) {
         logger() << "Open HoneyComb Bravo Quadrant not Detected";
@@ -135,25 +136,34 @@ state::init() noexcept
 
     auto commands = commands::init(*st);
     if(commands.has_value() == false) {
-        hid_close(st->hid_);
         logger() << "Failed to Register HoneyComb Bravo Commands";
         return std::unexpected(commands.error());
     }
     st->cmds_ = std::move(commands.value());
 
+#if !defined(NDEBUG)
     logger() << "Registering Error Handler";
     XPLMSetErrorCallback(&state::error_handler);
+#endif
 
     logger() << "Creating Menu Entries";
-    int item = XPLMAppendMenuItem(XPLMFindPluginsMenu(), "HoneyComb Bravo", nullptr, 1);
-    st->menu_ = XPLMCreateMenu("HoneyComb Bravo", XPLMFindPluginsMenu(), item, &state::menu_handler, st.get());
+    auto plugins_menu = XPLMFindPluginsMenu();
+    int item = XPLMAppendMenuItem(plugins_menu, "HoneyComb Bravo", nullptr, 1);
+    if(item < 0) {
+        logger() << "Failed to Create HoneyComb Bravo Menu Entry";
+        return std::unexpected(error::api_menu);
+    }
+    st->menu_item_ = item;
+    st->menu_ = XPLMCreateMenu("HoneyComb Bravo", plugins_menu, item, &state::menu_handler, st.get());
+    if(st->menu_ == nullptr) {
+        logger() << "Failed to Create HoneyComb Bravo Menu";
+        return std::unexpected(error::api_menu);
+    }
     if(XPLMAppendMenuItem(st->menu_, "Reload Aircraft Profiles", reinterpret_cast<void *>(0), 0) < 0) {
-        XPLMDestroyMenu(st->menu_);
         logger() << "Failed to Create HoneyComb Bravo Menu (Reload Aircraft Profiles)";
         return std::unexpected(error::api_menu);
     }
     if(XPLMAppendMenuItem(st->menu_, "Reload All Plugins", reinterpret_cast<void *>(1), 0) < 0) {
-        XPLMDestroyMenu(st->menu_);
         logger() << "Failed to Create HoneyComb Bravo Menu (Reload All Plugins)";
         return std::unexpected(error::api_menu);
     }
@@ -167,7 +177,6 @@ state::init() noexcept
     };
     st->flight_loop_ = XPLMCreateFlightLoop(&fl_params);
     if(st->flight_loop_ == nullptr) {
-        XPLMDestroyMenu(st->menu_);
         logger() << "Failed to Create Flight Loop";
         return std::unexpected(error::api_loop);
     }
@@ -186,7 +195,9 @@ static const char * plane_name_label_ = "sim/aircraft/view/acf_ui_name";
 
 state::state() noexcept :
     hid_(nullptr),
+    hid_initialized_(false),
     menu_(nullptr),
+    menu_item_(-1),
     cmds_(nullptr),
     plane_icao_data_ref_(
         XPLMFindDataRef(plane_icao_label_)
@@ -194,9 +205,43 @@ state::state() noexcept :
     plane_name_data_ref_(
         XPLMFindDataRef(plane_name_label_)
     ),
-    plane_(std::nullopt)
+    plane_(std::nullopt),
+    flight_loop_(nullptr)
 {
     this->reload();
+}
+
+state::~state() noexcept
+{
+    if(this->flight_loop_ != nullptr) {
+        XPLMDestroyFlightLoop(this->flight_loop_);
+        this->flight_loop_ = nullptr;
+    }
+
+    unload_plane();
+
+    if(this->menu_ != nullptr) {
+        XPLMDestroyMenu(this->menu_);
+        this->menu_ = nullptr;
+    }
+    if(this->menu_item_ >= 0) {
+        XPLMRemoveMenuItem(XPLMFindPluginsMenu(), this->menu_item_);
+        this->menu_item_ = -1;
+    }
+
+#if !defined(NDEBUG)
+    XPLMSetErrorCallback(nullptr);
+#endif
+
+    if(this->hid_ != nullptr) {
+        hid_close(this->hid_);
+        this->hid_ = nullptr;
+        this->leds_.hid_ = nullptr;
+    }
+    if(this->hid_initialized_) {
+        hid_exit();
+        this->hid_initialized_ = false;
+    }
 }
 
 void

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -212,7 +212,7 @@ read_data_ref_string(XPLMDataRef data_ref, char * buffer, size_t buffer_size, co
         return false;
     }
 
-    size_t written = std::min(static_cast<size_t>(ret), buffer_size - 1);
+    size_t written = (std::min)(static_cast<size_t>(ret), buffer_size - 1);
     buffer[written] = '\0';
     return true;
 }

--- a/src/state.h
+++ b/src/state.h
@@ -39,7 +39,7 @@ class state {
 
     XPLMFlightLoopID flight_loop_;
 
-    state() noexcept;
+    state();
 
     static
     void
@@ -65,7 +65,7 @@ public:
     init() noexcept;
 
     void
-    reload() noexcept;
+    reload();
 
     bool
     load_plane() noexcept;

--- a/src/state.h
+++ b/src/state.h
@@ -24,8 +24,10 @@
 
 class state {
     hid_device * hid_;
+    bool hid_initialized_;
     led_state leds_;
     XPLMMenuID menu_;
+    int menu_item_;
     commands::ptr_type cmds_;
 
     using profile_map_type = std::unordered_map<std::string, std::shared_ptr<profile>>;
@@ -56,12 +58,7 @@ public:
 
     inline state(state &&) noexcept = default;
 
-    inline
-    ~state() {
-        if(this->flight_loop_ != nullptr) XPLMDestroyFlightLoop(this->flight_loop_);
-        unload_plane();
-        if(this->hid_ != nullptr) hid_close(this->hid_);
-    }
+    ~state() noexcept;
 
     static
     result_type<state::ptr_type>

--- a/tests/profile-test.cpp
+++ b/tests/profile-test.cpp
@@ -11,6 +11,7 @@
 #define HCBRAVO_PROFILE_TESTS
 #include <profile.h>
 
+#include <fstream>
 #include <filesystem>
 
 
@@ -41,6 +42,52 @@ TEST(profile_test, bundled_profiles_load) {
     }
 
     EXPECT_GT(profile_count, 0);
+}
+
+TEST(profile_test, malformed_profile_returns_error) {
+    const auto path = std::filesystem::temp_directory_path() / "hcbravo-malformed-profile.yaml";
+    {
+        std::ofstream profile_file(path);
+        ASSERT_TRUE(profile_file.good());
+        profile_file << R"(
+name: Invalid
+aircrafts:
+ - Invalid
+models:
+ - BAD
+system:
+ volts:
+  - key: 'sim/test/bool'
+    type:
+     - not-a-scalar
+)";
+    }
+
+    const auto prof = profile::from_yaml(path.string());
+    std::filesystem::remove(path);
+    EXPECT_FALSE(prof.has_value());
+}
+
+TEST(profile_test, required_empty_data_ref_returns_error) {
+    const auto path = std::filesystem::temp_directory_path() / "hcbravo-empty-data-ref-profile.yaml";
+    {
+        std::ofstream profile_file(path);
+        ASSERT_TRUE(profile_file.good());
+        profile_file << R"(
+name: Invalid
+aircrafts:
+ - Invalid
+models:
+ - BAD
+system:
+ volts:
+  - no_key: 'sim/test/bool'
+)";
+    }
+
+    const auto prof = profile::from_yaml(path.string());
+    std::filesystem::remove(path);
+    EXPECT_FALSE(prof.has_value());
 }
 
 TEST(profile_test, bool_data_ref_scalar) {

--- a/tests/profile-test.cpp
+++ b/tests/profile-test.cpp
@@ -90,6 +90,29 @@ system:
     EXPECT_FALSE(prof.has_value());
 }
 
+TEST(profile_test, negative_data_ref_index_returns_error) {
+    const auto path = std::filesystem::temp_directory_path() / "hcbravo-negative-index-profile.yaml";
+    {
+        std::ofstream profile_file(path);
+        ASSERT_TRUE(profile_file.good());
+        profile_file << R"(
+name: Invalid
+aircrafts:
+ - Invalid
+models:
+ - BAD
+system:
+ volts:
+  - key: 'sim/test/bool'
+    index: -1
+)";
+    }
+
+    const auto prof = profile::from_yaml(path.string());
+    std::filesystem::remove(path);
+    EXPECT_FALSE(prof.has_value());
+}
+
 TEST(profile_test, bool_data_ref_scalar) {
     auto node = YAML::Load(R"(
 tag: 'sim/test/bool'


### PR DESCRIPTION
## Summary

This PR fixes the safety and reliability issues found during the codebase audit.

- Harden profile YAML parsing so malformed profile data fails profile loading instead of escaping through `noexcept` paths.
- Add regression coverage for malformed profiles, empty required DataRefs, and negative DataRef indexes.
- Fix plugin lifecycle cleanup for HID, flight loop, menu entries, and debug error callback registration.
- Validate release workflow version input before shell use and quote release commands.
- Harden DataRef array access by using the SDK offset type, rejecting negative indexes, honoring bitfield DataRef types, and avoiding uninitialized float reads.
- Harden XPLM string/directory reads to avoid unterminated aircraft names and config reload hangs.
- Preserve LED cached state when HID sends fail so the next update can retry.

## Validation

- `cmake --build build`
- `ctest --test-dir build --output-on-failure`

Both pass locally.